### PR TITLE
fix: Go to today's lesson when press Read

### DIFF
--- a/src/views/Lessons.vue
+++ b/src/views/Lessons.vue
@@ -90,11 +90,10 @@ export default {
       if (!this.quarterly || !this.quarterly.lessons.length) { return null }
       let now = DayJS().startOf("day")
       let lesson = this.quarterly.lessons.find(x => {
-        let startDate = DayJS(x.start_date, "DD/MM/YYYY").startOf("day")
-        let endDate = DayJS(x.end_date, "DD/MM/YYYY").endOf("day")
+        let startDate = x.start_date
+        let endDate = x.end_date
         return DayJS(now).isBetween(startDate, endDate, "day")
       }) || this.quarterly.lessons[0]
-
       return `/${this.$route.params.lang}/${this.$route.params.quarter}/${lesson.id}`
     }
   },


### PR DESCRIPTION
I don't know why the lesson's date is formatted to a format that is already present in the property. For some reason this caused the date obtained is an ISO format, and when compared with .isBetween, doesn't work.

If there is a reason to keep the formatted, just let me know to find another way.

With this PR, when user press READ button, he goes to the lesson of the day, not the first lesson of the quarter.