### PR TITLE
Fix height for proper title wrapping

### DIFF
--- a/src/views/Read.vue
+++ b/src/views/Read.vue
@@ -36,7 +36,7 @@
     </div>
     <div class="mt-4 ml-0 md:ml-6 md:mt-0 mb-4 md:mb-0 grow order-0 md:order-1 md:w-3/12 lg:w-9/12 xl:w-10/12">
       <div v-if="lesson" class="rounded border border-1 border-gray-150 h-full">
-        <div v-if="read" :style="`background-image: url('${lesson.lesson.cover}')`" class="rounded-t h-ss-cover bg-center bg-cover flex flex-col">
+        <div v-if="read" :style="`background-image: url('${lesson.lesson.cover}')`" class="rounded-t min-h-ss-cover bg-center bg-cover flex flex-col">
           <div class="flex justify-end p-2">
             <div class="pb-2 pt-3 px-5 bg-black/[.6] flex rounded-lg">
               <ReaderOptions class="mt-2"></ReaderOptions>


### PR DESCRIPTION
In mobile view, the lesson title sometimes doesn't fit within the designated height, causing it to overlap with the element containing the verses.

for example: https://sabbath-school.adventech.io/en/2025-01/12/01

![image](https://github.com/user-attachments/assets/16503830-e094-4172-9f23-be64c66e73df)

- Fix the cover div height to ensure proper title wrapping.