### PR TITLE
fix: typo in Portuguese language label

### DIFF
--- a/src/locales.js
+++ b/src/locales.js
@@ -19,7 +19,7 @@ const locales = [
     },
     {
         "native": "Português",
-        "en": "Portugese",
+        "en": "Portuguese",
         "code": "pt",
         "flag": "🇧🇷"
     },

--- a/src/views/Languages.vue
+++ b/src/views/Languages.vue
@@ -50,7 +50,7 @@ export default {
         },
         {
           "native": "Português",
-          "en": "Portugese",
+          "en": "Portuguese",
           "code": "pt"
         },
         {


### PR DESCRIPTION
There was a typo in the Portuguese label, which said `Portugese`.