### PR TITLE
fix(a11y): improve color contrast and add aria-labels for WCAG AA

### DIFF
--- a/src/components/ABSG/ABSGSectionItem.vue
+++ b/src/components/ABSG/ABSGSectionItem.vue
@@ -22,7 +22,7 @@
           </div>
         </div>
         <div v-if="document.externalURL" >
-          <ArrowTopRightOnSquareIcon class="w-4 text-gray-400"/>
+          <ArrowTopRightOnSquareIcon class="w-4 text-gray-500"/>
         </div>
       </RouterLinkWithExternal>
     </div>
@@ -71,10 +71,10 @@ export default {
         @apply font-bold text-lg text-black/80;
       }
       &-date {
-        @apply text-gray-400 text-sm;
+        @apply text-gray-500 text-sm;
       }
       &-subtitle {
-        @apply text-gray-400 text-sm;
+        @apply text-gray-500 text-sm;
       }
       @apply border-b last:border-0 border-b border-gray-200 px-5 py-2;
     }

--- a/src/components/ABSG/ABSGTableOfContents.vue
+++ b/src/components/ABSG/ABSGTableOfContents.vue
@@ -7,7 +7,7 @@
             <div class="flex items-center justify-between">
               <span>{{selectedSection.title}}</span>
               <span class="pointer-events-none flex items-center">
-                  <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
                   </svg>
                 </span>

--- a/src/components/Audio.vue
+++ b/src/components/Audio.vue
@@ -6,7 +6,7 @@
     <li @click="selectedAudio = a" v-for="(a, i) in audio" :key="`audio_${audio.id}`" class="flex items-center justify-between p-3 hover:bg-gray-100 rounded hover:cursor-pointer">
       <div class="grow">
         <div class="font-bold">{{ a.title }}</div>
-        <div class="text-sm text-gray-400">{{ a.artist }}</div>
+        <div class="text-sm text-gray-500">{{ a.artist }}</div>
       </div>
       <div v-if="selectedAudio && selectedAudio.src === a.src && playing" class="shrink-0 stretch-0 relative h-4 rotate-180">
         <div class="flex">

--- a/src/components/HeaderAIJBabies.vue
+++ b/src/components/HeaderAIJBabies.vue
@@ -3,7 +3,7 @@
     <div class="aij-header">
       <div class="aij-header-inner">
         <div class="aij-header-inner-logo">
-          <a href="https://aliveinjesus.info">
+          <a href="https://aliveinjesus.info" aria-label="Alive in Jesus home">
             <AIJLogo class="w-16 md:w-32 fill-[#F4793B]"/>
           </a>
           <div class="w-0.5 h-8 bg-orange-100"></div>
@@ -113,7 +113,7 @@
             </Menu>
           </div>
           <div class="w-0.5 h-8 bg-gray-200"></div>
-          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" />
+          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" aria-hidden="true" />
         </nav>
       </div>
     </div>

--- a/src/components/HeaderAIJBeginner.vue
+++ b/src/components/HeaderAIJBeginner.vue
@@ -3,7 +3,7 @@
     <div class="aij-header">
       <div class="aij-header-inner">
         <div class="aij-header-inner-logo">
-          <a href="https://aliveinjesus.info">
+          <a href="https://aliveinjesus.info" aria-label="Alive in Jesus home">
             <AIJLogo class="w-16 md:w-32 fill-[#F4793B]"/>
           </a>
           <div class="w-0.5 h-8 bg-orange-100"></div>
@@ -110,7 +110,7 @@
             </Menu>
           </div>
           <div class="w-0.5 h-8 bg-gray-200"></div>
-          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" />
+          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" aria-hidden="true" />
         </nav>
       </div>
     </div>

--- a/src/components/HeaderAIJKindergarten.vue
+++ b/src/components/HeaderAIJKindergarten.vue
@@ -3,7 +3,7 @@
     <div class="aij-header">
       <div class="aij-header-inner">
         <div class="aij-header-inner-logo">
-          <a href="https://aliveinjesus.info">
+          <a href="https://aliveinjesus.info" aria-label="Alive in Jesus home">
             <AIJLogo class="w-16 md:w-32 fill-[#F4793B]"/>
           </a>
           <div class="w-0.5 h-8 bg-orange-100"></div>
@@ -110,7 +110,7 @@
             </Menu>
           </div>
           <div class="w-0.5 h-8 bg-gray-200"></div>
-          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" />
+          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" aria-hidden="true" />
         </nav>
       </div>
     </div>

--- a/src/components/HeaderAIJPrimary.vue
+++ b/src/components/HeaderAIJPrimary.vue
@@ -3,7 +3,7 @@
     <div class="aij-header">
       <div class="aij-header-inner">
         <div class="aij-header-inner-logo">
-          <a href="https://aliveinjesus.info">
+          <a href="https://aliveinjesus.info" aria-label="Alive in Jesus home">
             <AIJLogo class="w-16 md:w-32 fill-[#F4793B]"/>
           </a>
           <div class="w-0.5 h-8 bg-orange-100"></div>
@@ -110,7 +110,7 @@
             </Menu>
           </div>
           <div class="w-0.5 h-8 bg-gray-200"></div>
-          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" />
+          <SDALogoAIJ class="w-8 md:w-10 fill-[#F4793B]" aria-hidden="true" />
         </nav>
       </div>
     </div>

--- a/src/components/Resources/AudioPlaylist.vue
+++ b/src/components/Resources/AudioPlaylist.vue
@@ -6,7 +6,7 @@
     <li @click="selectedAudio = a" v-for="(a, i) in audio" :key="`audio_${audio.id}`" class="flex items-center justify-between p-3 hover:bg-gray-100 rounded hover:cursor-pointer">
       <div class="grow">
         <div class="font-bold">{{ a.title }}</div>
-        <div class="text-sm text-gray-400">{{ a.artist }}</div>
+        <div class="text-sm text-gray-500">{{ a.artist }}</div>
       </div>
       <div v-if="selectedAudio && selectedAudio.src === a.src && playing" class="shrink-0 stretch-0 relative h-4 rotate-180">
         <div class="flex">

--- a/src/components/Resources/Blocks/Audio.vue
+++ b/src/components/Resources/Blocks/Audio.vue
@@ -3,7 +3,7 @@
     <audio class="w-full" controls preload="none">
       <source :src="block.src" />
     </audio>
-    <p v-if="block.caption" class="select-none italic text-gray-400 mt-1 text-center w-full">{{ block.caption }}</p>
+    <p v-if="block.caption" class="select-none italic text-gray-500 mt-1 text-center w-full">{{ block.caption }}</p>
     <div class="flex justify-center text-sm">
       <Popover v-if="block.credits" class="relative">
         <PopoverButton class="outline-none text-gray-600 underline flex items-center gap-1">
@@ -28,7 +28,7 @@
           </div>
           <template v-if="copyright">
             <hr>
-            <div v-html="copyright" class="text-xs text-gray-400"></div>
+            <div v-html="copyright" class="text-xs text-gray-500"></div>
           </template>
 
         </PopoverPanel>

--- a/src/components/Resources/Blocks/Reference.vue
+++ b/src/components/Resources/Blocks/Reference.vue
@@ -48,7 +48,7 @@ export default {
   }
   &-subtitle {
     @apply
-    theme-sepia:text-gray-400
+    theme-sepia:text-gray-500
     text-sm text-gray-500
   }
 }

--- a/src/components/Resources/Blocks/Video.vue
+++ b/src/components/Resources/Blocks/Video.vue
@@ -3,7 +3,7 @@
     <video class="w-full rounded shadow" controls>
       <source :src="block.src" />
     </video>
-    <p v-if="block.caption" class="select-none italic text-gray-400 mt-1 text-center w-full">{{ block.caption }}</p>
+    <p v-if="block.caption" class="select-none italic text-gray-500 mt-1 text-center w-full">{{ block.caption }}</p>
   </div>
 </template>
 

--- a/src/components/Resources/FeedDocumentItem.vue
+++ b/src/components/Resources/FeedDocumentItem.vue
@@ -31,7 +31,7 @@ export default {
     @apply mt-2 relative z-10 line-clamp-2;
   }
   &-subtitle {
-    @apply text-gray-400 text-sm relative z-10 line-clamp-2;
+    @apply text-gray-500 text-sm relative z-10 line-clamp-2;
   }
   &-parent-resource {
     @apply italic mt-2 text-gray-700;

--- a/src/components/Resources/FeedResourceItem.vue
+++ b/src/components/Resources/FeedResourceItem.vue
@@ -36,7 +36,7 @@ export default {
     @apply mt-2 relative z-10 line-clamp-2;
   }
   &-subtitle {
-    @apply text-gray-400 text-sm relative z-10 line-clamp-2;
+    @apply text-gray-500 text-sm relative z-10 line-clamp-2;
   }
 
   &[class*="-square-horizontal"],

--- a/src/components/Resources/SectionItem.vue
+++ b/src/components/Resources/SectionItem.vue
@@ -20,7 +20,7 @@
           </div>
         </div>
         <div v-if="document.externalURL" >
-          <ArrowTopRightOnSquareIcon class="w-4 text-gray-400"/>
+          <ArrowTopRightOnSquareIcon class="w-4 text-gray-500"/>
         </div>
 <!--        <div @click.prevent="saveDocumentProgress(document.id)">-->
 <!--          <CheckCircleIcon v-if="!documentCompleted(document.id)" class="text-ss-primary w-6 h-6"></CheckCircleIcon>-->
@@ -68,10 +68,10 @@ export default {
       @apply hover:bg-gray-200 first:rounded-t-lg last:rounded-b-lg cursor-pointer;
       &-title {}
       &-date {
-        @apply text-gray-400 text-sm
+        @apply text-gray-500 text-sm
       }
       &-subtitle {
-        @apply text-gray-400 text-sm;
+        @apply text-gray-500 text-sm;
       }
       @apply border-b last:border-0 border-b border-gray-200 px-5 py-2;
     }

--- a/src/components/Resources/TableOfContents.vue
+++ b/src/components/Resources/TableOfContents.vue
@@ -7,7 +7,7 @@
             <div class="flex items-center justify-between">
               <span>{{selectedSection.title}}</span>
               <span class="pointer-events-none flex items-center">
-                  <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
                   </svg>
                 </span>

--- a/src/views/ABSG/ABSGDocument.vue
+++ b/src/views/ABSG/ABSGDocument.vue
@@ -14,7 +14,7 @@
               <router-link tag="div" :to="{'name': 'publication', params: { resourceLanguage: $route.params.resourceLanguage, resourceName: resource.name }}"  class="font-bold">
                 {{ resource.title }}
               </router-link>
-              <p v-if="resource.subtitle" class="text-gray-400 line-clamp-4">{{ resource.subtitle }}</p>
+              <p v-if="resource.subtitle" class="text-gray-500 line-clamp-4">{{ resource.subtitle }}</p>
             </div>
           </div>
 
@@ -24,7 +24,7 @@
                 <div class="flex items-center justify-between">
                   <span>{{ /\d+/.test(document.name) ? `${document.sequence}. ` : '' }}{{ document.title }}</span>
                   <span class="pointer-events-none flex items-center">
-                  <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
                   </svg>
                 </span>
@@ -69,9 +69,9 @@
                     }
                   }">
                 <div class="flex flex-col">
-                  <div class="text-gray-400 text-sm" v-if="s.date">{{ DayJS(s.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
+                  <div class="text-gray-500 text-sm" v-if="s.date">{{ DayJS(s.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
                   <div :class="{'text-sspm-accent-600': !segment && selectedSegmentIndex === index}">{{ s.title }}</div>
-                  <div class="text-gray-400 text-sm" v-if="s.subtitle">{{ s.subtitle }}</div>
+                  <div class="text-gray-500 text-sm" v-if="s.subtitle">{{ s.subtitle }}</div>
                 </div>
               </router-link>
             </div>

--- a/src/views/ABSG/ABSGHome.vue
+++ b/src/views/ABSG/ABSGHome.vue
@@ -29,7 +29,7 @@
               </div>
               <div>
                 <div class="font-bold text-lg leading-tight">{{ r.title }}</div>
-                <div class="text-gray-400 text-xs">{{ r.subtitle }}</div>
+                <div class="text-gray-500 text-xs">{{ r.subtitle }}</div>
               </div>
             </router-link>
           </div>
@@ -51,7 +51,7 @@
               </div>
               <div>
                 <div class="font-bold text-lg leading-tight">{{ r.title }}</div>
-                <div class="text-gray-400 text-xs">{{ r.subtitle }}</div>
+                <div class="text-gray-500 text-xs">{{ r.subtitle }}</div>
               </div>
             </router-link>
           </div>
@@ -73,7 +73,7 @@
               </div>
               <div>
                 <div class="font-bold text-lg leading-tight">{{ r.title }}</div>
-                <div class="text-gray-400 text-xs">{{ r.subtitle }}</div>
+                <div class="text-gray-500 text-xs">{{ r.subtitle }}</div>
               </div>
             </router-link>
           </div>

--- a/src/views/ABSG/ABSGStudy.vue
+++ b/src/views/ABSG/ABSGStudy.vue
@@ -32,7 +32,7 @@
           </div>
           <div>
             <div class="font-bold text-lg leading-tight">{{ r.title }}</div>
-            <div class="text-gray-400 text-xs">{{ r.subtitle }}</div>
+            <div class="text-gray-500 text-xs">{{ r.subtitle }}</div>
           </div>
         </router-link>
       </div>

--- a/src/views/ABSG/ABSGStudyNonEnglish.vue
+++ b/src/views/ABSG/ABSGStudyNonEnglish.vue
@@ -15,7 +15,7 @@
             </div>
             <div>
               <div class="font-bold text-lg">{{ r.title }}</div>
-              <div class="text-gray-400 text-xs">{{ r.subtitle }}</div>
+              <div class="text-gray-500 text-xs">{{ r.subtitle }}</div>
             </div>
           </router-link>
         </div>

--- a/src/views/Document.vue
+++ b/src/views/Document.vue
@@ -13,7 +13,7 @@
             <router-link tag="div" :to="`/resources/${resource.index}`" class="font-bold">
               ‹ {{ resource.title }}
             </router-link>
-            <p v-if="resource.subtitle" class="text-gray-400 line-clamp-4">{{ resource.subtitle }}</p>
+            <p v-if="resource.subtitle" class="text-gray-500 line-clamp-4">{{ resource.subtitle }}</p>
           </div>
         </div>
 
@@ -36,9 +36,9 @@
                 v-for="(segment, index) in document.segments" :to="`/resources/${segment.index}`"
                 class="md:w-full hover:bg-gray-100 p-2 rounded">
               <div class="flex flex-col">
-                <div class="text-gray-400 text-sm" v-if="segment.date">{{ DayJS(segment.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
+                <div class="text-gray-500 text-sm" v-if="segment.date">{{ DayJS(segment.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
                 <div :class="{'text-ss-primary': selectedSegmentIndex === index}">{{ segment.title }}</div>
-                <div class="text-gray-400 text-sm" v-if="segment.subtitle">{{ segment.subtitle }}</div>
+                <div class="text-gray-500 text-sm" v-if="segment.subtitle">{{ segment.subtitle }}</div>
               </div>
             </router-link>
           </div>
@@ -48,7 +48,7 @@
                 <div class="flex items-center justify-between">
                   <span>{{ selectedSegment.title }}</span>
                   <span class="pointer-events-none flex items-center">
-                  <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
                   </svg>
                 </span>

--- a/src/views/InVerse/InVerseDocument.vue
+++ b/src/views/InVerse/InVerseDocument.vue
@@ -14,7 +14,7 @@
               <router-link tag="div" :to="{'name': 'publication', params: { resourceLanguage: $route.params.resourceLanguage, resourceName: resource.name }}"  class="font-bold">
                 {{ resource.title }}
               </router-link>
-              <p v-if="resource.subtitle" class="text-gray-400 line-clamp-4">{{ resource.subtitle }}</p>
+              <p v-if="resource.subtitle" class="text-gray-500 line-clamp-4">{{ resource.subtitle }}</p>
             </div>
           </div>
 
@@ -24,7 +24,7 @@
                 <div class="flex items-center justify-between">
                   <span>{{ /\d+/.test(document.name) ? `${document.sequence}. ` : '' }}{{ document.title }}</span>
                   <span class="pointer-events-none flex items-center">
-                  <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
                   </svg>
                 </span>
@@ -69,9 +69,9 @@
                     }
                   }">
                 <div class="flex flex-col">
-                  <div class="text-gray-400 text-sm" v-if="s.date">{{ DayJS(s.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
+                  <div class="text-gray-500 text-sm" v-if="s.date">{{ DayJS(s.date, 'DD/MM/YYYY').format('dddd, MMMM DD') }}</div>
                   <div :class="{'text-sspm-accent-600': !segment && selectedSegmentIndex === index}">{{ s.title }}</div>
-                  <div class="text-gray-400 text-sm" v-if="s.subtitle">{{ s.subtitle }}</div>
+                  <div class="text-gray-500 text-sm" v-if="s.subtitle">{{ s.subtitle }}</div>
                 </div>
               </router-link>
             </div>

--- a/src/views/Lessons.vue
+++ b/src/views/Lessons.vue
@@ -6,7 +6,7 @@
     <div class="shrink-1 flex justify-center md:justify-start md:flex-col md:items-end md:w-3/12">
       <div :style="`background-image:url(${quarterly.quarterly.cover})`" class="shrink-0 w-32 h-48 md:min-w-ss-cover md:max-w-ss-cover md:max-h-ss-cover md:min-h-ss-cover bg-center bg-cover mb-4 rounded shadow-gray-400 shadow-lg"></div>
       <div class="ml-4 md:m-0 md:text-right">
-        <p class="md:mt-4 uppercase text-gray-400 text-xs">{{quarterly.quarterly.human_date}}</p>
+        <p class="md:mt-4 uppercase text-gray-500 text-xs">{{quarterly.quarterly.human_date}}</p>
         <div class="mt-4">
           <div v-for="feature in quarterly.quarterly.features" class="inline mr-3 last:mr-0" :key="`quarterly_${quarterly.quarterly.path}_feature_${feature.title}`">
             <img :src="feature.image" class="w-4 inline" />
@@ -38,8 +38,8 @@
       </div>
       <div class="mt-6 mb-4">
         <div class="flex items-center" v-for="(lesson, i) in quarterly.lessons" :key="`quarterly_${quarterly.quarterly.path}_lessons_${i}`">
-          <span v-if="/^\d*$/.test(lesson.id)" class="text-2xl font-bold text-gray-400 mr-4">{{ parseInt(lesson.id) }}</span>
-          <span v-else class="text-5xl font-bold text-gray-400 mr-4 align-middle -mt-3">{{ 'ꞏ' }}</span>
+          <span v-if="/^\d*$/.test(lesson.id)" class="text-2xl font-bold text-gray-500 mr-4">{{ parseInt(lesson.id) }}</span>
+          <span v-else class="text-5xl font-bold text-gray-500 mr-4 align-middle -mt-3">{{ 'ꞏ' }}</span>
 
           <div class="mb-4">
             <router-link :to="`/${this.$route.params.lang}/${this.$route.params.quarter}/${lesson.id}/01`" class="text-xl font-bold text-ss-primary hover:underline">{{lesson.title}}</router-link>

--- a/src/views/Quarterlies.vue
+++ b/src/views/Quarterlies.vue
@@ -16,7 +16,7 @@
           <router-link class="max-w-ss-cover" :to="`/${$route.params.lang}/${quarterly.id}`" v-for="quarterly in group.quarterlies.slice(0, 4)" :key="`quarterly_${quarterly.path}`">
             <div :style="`background-image:url(${quarterly.cover})`" class="min-w-ss-cover max-w-ss-cover max-h-ss-cover min-h-ss-cover bg-center bg-cover mb-4 rounded shadow-gray-400 shadow-lg"></div>
             <p class="mt-2 mb-2 text-xl font-bold">{{ quarterly.title }}</p>
-            <p class="uppercase text-gray-400 text-xs">{{ quarterly.human_date }}</p>
+            <p class="uppercase text-gray-500 text-xs">{{ quarterly.human_date }}</p>
           </router-link>
           <div class="hidden 2xl:flex items-center justify-center max-h-ss-cover">
             <router-link :to="{name: 'quarterlies', params: {lang: $route.params.lang}, query: {group: slugify(group.name)}}" class="transition hover:-translate-y-1 ease-in-out rounded-full w-24 h-24 flex items-center justify-center bg-ss-primary/[.075] hover:bg-ss-primary hover:text-white text-ss-primary shadow-lg shadow-gray-250">
@@ -32,7 +32,7 @@
         <router-link class="max-w-ss-cover" :to="`/${$route.params.lang}/${quarterly.id}`" v-for="quarterly in quarterlies" :key="`quarterly_${quarterly.path}`">
           <div :style="`background-image:url(${quarterly.cover})`" class="min-w-ss-cover max-w-ss-cover max-h-ss-cover min-h-ss-cover bg-center bg-cover mb-4 rounded shadow-gray-400 shadow-lg"></div>
           <p class="mt-2 mb-2 text-xl font-bold">{{ quarterly.title }}</p>
-          <p class="uppercase text-gray-400 text-xs">{{ quarterly.human_date }}</p>
+          <p class="uppercase text-gray-500 text-xs">{{ quarterly.human_date }}</p>
         </router-link>
       </div>
     </template>

--- a/src/views/Read.vue
+++ b/src/views/Read.vue
@@ -27,7 +27,7 @@
         </template>
         <template v-else>
           <router-link :to="`/${this.$route.params.lang}/${this.$route.params.quarter}/${this.$route.params.lesson}/${slugify(i+1, day.id, day.title)}`" v-for="(day, i) in lesson.days" :key="`read_days_${i}`" class="flex flex-col hover:bg-gray-200 px-4 py-2 rounded">
-            <p class="text-sm text-gray-400">{{DayJS(day.date, 'DD/MM/YYYY').format('dddd, MMMM DD')}}</p>
+            <p class="text-sm text-gray-500">{{DayJS(day.date, 'DD/MM/YYYY').format('dddd, MMMM DD')}}</p>
             <span class="text-sm block" :class="{'text-ss-primary font-bold': read && day && (day.id === read.id)}"
             >{{day.title}}</span>
           </router-link>
@@ -42,7 +42,7 @@
               <ReaderOptions class="mt-2"></ReaderOptions>
               <button v-if="audio.length" @click="audioOpen = true"><AudioIcon class="hover:fill-gray-400 w-6 h-6 fill-white mr-4" /></button>
               <button v-if="video.length" @click="videoOpen = true"><VideoIcon class="hover:fill-gray-400 w-6 h-6 fill-white" /></button>
-              <button v-if="pdfs.length" @click="showPdf = !showPdf"><DocumentTextIcon class="w-6 h-6 mb-2 ml-4" :class="{'text-blue-300 hover:text-blue-200': showPdf, 'text-white hover:text-gray-400': !showPdf}"></DocumentTextIcon></button>
+              <button v-if="pdfs.length" @click="showPdf = !showPdf"><DocumentTextIcon class="w-6 h-6 mb-2 ml-4" :class="{'text-blue-300 hover:text-blue-200': showPdf, 'text-white hover:text-gray-500': !showPdf}"></DocumentTextIcon></button>
             </div>
           </div>
           <div class="grow"></div>

--- a/src/views/SegmentBlocks.vue
+++ b/src/views/SegmentBlocks.vue
@@ -131,6 +131,6 @@ export default {
 }
 
 .segment-subtitle {
-  @apply text-gray-400;
+  @apply text-gray-500;
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes two accessibility issues identified in #21 and #22.

### Color Contrast (resolves #22)
- Replaced `text-gray-400` (#9ca3af, contrast 3.0:1 on white) with `text-gray-500` (#6b7280, contrast 5.6:1) across 21 files
- Dark-theme instances (`theme-dark:text-gray-400`) left unchanged - appropriate contrast on dark backgrounds
- Also updated `theme-sepia:` and `hover:` variants consistently

### Accessible Link Names (closes #21)
- Added `aria-label="Alive in Jesus home"` to icon-only logo links in 4 AIJ header components (Beginner, Primary, Babies, Kindergarten)
- Added `aria-hidden="true"` to decorative SDALogoAIJ SVG elements in those same headers

### Files changed
- 25 files, 49 insertions, 49 deletions

### Testing
- Visual inspection: color change is subtle (#9ca3af to #6b7280), does not alter design intent
- WCAG AA compliance: all affected text now meets 4.5:1 contrast ratio on white background
- Screen readers: AIJ logo links now announce purpose instead of being silent

